### PR TITLE
Actualize version of required package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "symfony/framework-bundle": "2.*",
-        "kwattro/markdown-bundle": "*",
+        "kwattro/markdown-bundle": "dev-master",
         "php": ">=5.3"
     },
     "autoload": {


### PR DESCRIPTION
If install this bundle through composer https://github.com/varspool/WebsocketBundle#composer I recieve following error:
```
  Problem 1
    - Installation request for varspool/websocket-bundle dev-master -> satisfiable by varspool/websocket-bundle[dev-master].
    - varspool/websocket-bundle dev-master requires kwattro/markdown-bundle * -> no matching package found.
```
composer doesn't find version [dev-master] of required package https://packagist.org/packages/kwattro/markdown-bundle