### PR TITLE
Show more clearly possibility of configuring

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,10 @@ varspool_websocket:
             applications:
                 - echo
                 - multiplex
-
+                
+            # Class of Wrench websocket Server 
+            class Varspool\WebsocketBundle\Server\Server
+            
             # Origin control
             check_origin: true
             allow_origin: # default: just localhost (not useful!)


### PR DESCRIPTION
I just suggest to show a default value in the config file. Because the [possibility of changing Server class](https://github.com/varspool/WebsocketBundle/blob/master/DependencyInjection/Configuration.php#L31) from this bundle to Wrench one wasn't so obvious.
Moreover, I can't launch server with default class. There was a strange behavior with array of listeners and events. Server closes socket before it recieves data from client. If it neccessary, I can research this problem and dig up more information. But when I switched to [Wrench\Server](https://github.com/varspool/Wrench/blob/master/lib/Wrench/Server.php) everything was solved.
Why do you use as default Server/Application classes from this bundle? Aren't they duplicate classes from the Wrench lib? Aren't better to use classes from big library, which continues to be maintained.
