### PR TITLE
Actualize readme composer dependence part

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ requires:
 {
     "require": {
         "varspool/websocket-bundle": "dev-master",
+	"kwattro/markdown-bundle": "dev-master",
         "wrench/wrench": "dev-master"
     }
 }


### PR DESCRIPTION
Unfortunatelly, [this PR](https://github.com/varspool/WebsocketBundle/pull/5) didn't help.
The fact that the composer is very strict now for developer versions of dependency packages. You can use [dev-master] only in root bundle, not in dependent ones.
[More info here](https://github.com/composer/composer/issues/1478).
